### PR TITLE
fixed hoverover timestamp when viewing messages

### DIFF
--- a/resources/assets/js/components/Message.vue
+++ b/resources/assets/js/components/Message.vue
@@ -91,7 +91,7 @@ export default {
 		 */
 		date () {
 			if (moment(this.list.created_at).format('DD/MM/YYYY') == moment(new Date()).format('DD/MM/YYYY')) {
-				return moment().utc(this.list.created_at).format("LT")
+				return moment(this.list.created_at).utc().format("LT")
 			}
 
 			return moment(this.list.created_at).utc(moment().format("MMM Do")).format("MMM Do")
@@ -103,7 +103,7 @@ export default {
 		 * @return String
 		 */
 		longDate () {
-			return moment().utc(this.list.created_at).format("LLL")
+			return moment(this.list.created_at).utc().format("LLL")
 		},
 
 		/**
@@ -113,7 +113,7 @@ export default {
 		 */
 		seenDate () {
 			if (this.list.read_at) {
-				return moment().utc(this.list.read_at).format("LLL")
+				return moment(this.list.read_at).utc().format("LLL")
 			}
 
 			return "Not seen yet"

--- a/resources/assets/js/components/Message.vue
+++ b/resources/assets/js/components/Message.vue
@@ -91,10 +91,10 @@ export default {
 		 */
 		date () {
 			if (moment(this.list.created_at).format('DD/MM/YYYY') == moment(new Date()).format('DD/MM/YYYY')) {
-				return moment(this.list.created_at).utc().format("LT")
+				return moment(this.list.created_at).format("LT")
 			}
 
-			return moment(this.list.created_at).utc(moment().format("MMM Do")).format("MMM Do")
+			return moment(this.list.created_at).format("MMM Do")
 		},
 
 		/**
@@ -103,7 +103,7 @@ export default {
 		 * @return String
 		 */
 		longDate () {
-			return moment(this.list.created_at).utc().format("LLL")
+			return moment(this.list.created_at).format("LLL")
 		},
 
 		/**
@@ -113,7 +113,7 @@ export default {
 		 */
 		seenDate () {
 			if (this.list.read_at) {
-				return moment(this.list.read_at).utc().format("LLL")
+				return moment(this.list.read_at).format("LLL")
 			}
 
 			return "Not seen yet"


### PR DESCRIPTION
when a user hovered over the "Sent At" timestamp on a message page, it would be the current date. there was a problem with the way momentjs was being initialized and used with utc(). this probably exists elsewhere but this is the fix for the message page.
(-aaa)