### PR TITLE
Fix for link submission validation error not giving feedback to user

### DIFF
--- a/resources/assets/js/components/Submit.vue
+++ b/resources/assets/js/components/Submit.vue
@@ -301,15 +301,16 @@
                     this.$router.push('/c/' + this.selectedCat + '/' + response.data.slug)
 
 					this.loading = false
-                }, (response) => {
+                }, (error) => {
                     // error
-                    if(response.status == 500){
-                        this.customError = response.data
+                    if(error.response.status == 500){
+                        this.customError = error.response.data
                         this.errors = []
                         this.loading = false
                         return
                     }
-                    this.errors = response.data
+
+                    this.errors = error.response.data
                     this.loading = false
                 })
             },


### PR DESCRIPTION
When a validation occurs, the user was left looking at the spinner, as the error response was not correctly retrieved from the error callback. Confirmed the error in the test channel on production.