### PR TITLE
Toggle guest sidebar when clicking sign up from sidebar

### DIFF
--- a/resources/assets/js/components/GuestSidebar.vue
+++ b/resources/assets/js/components/GuestSidebar.vue
@@ -13,7 +13,7 @@
         		Sign up now to get your own personalized timeline, modified sidebar, customizable design, and real-time experience!
         	</p>
 
-        	<button class="v-button v-button--block" @click="mustBeLogin">
+        	<button class="v-button v-button--block" @click="signUp">
         		Sign up
         	</button>
         </div>
@@ -120,6 +120,10 @@ export default {
         changeRoute: function(newRoute) {
         	this.$eventHub.$emit('new-route', newRoute)
         },
+        signUp: function(){
+            this.$eventHub.$emit('toggle-sidebar');
+            this.mustBeLogin();
+        }
     },
 }
 </script>


### PR DESCRIPTION
If you're on mobile and click the sign up button from the expanded sidebar, you can't sign up because the modal is to the right of the expanded sidebar. This pulls through to desktop too, but in my opinion I prefer the modal centered on desktop as well if clicked from the sidebar