### PR TITLE
Fix the email logo width

### DIFF
--- a/resources/views/layouts/email-layout.blade.php
+++ b/resources/views/layouts/email-layout.blade.php
@@ -151,7 +151,7 @@
 	<div class="container">
 		<div class="align-center">
 			<a href="https://voten.co">
-				<img src="https://voten.co/imgs/voten-circle.png" alt="Voten" class="logo">
+				<img src="https://voten.co/imgs/voten-circle.png" alt="Voten" class="logo" width="150">
 			</a>
 		</div>
 


### PR DESCRIPTION
The logo appears very large for the Registration email. 

The change applies the width of 150px.