### PR TITLE
bound sentry before capturing the exception

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,5 @@ FACEBOOK_REDIRECT=https://voten.co/login/facebook/callback
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT=https://voten.co/login/google/callback
+
+SENTRY_DSN=https://somestring:someotherstring@sentry.io/somenumbers

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -37,7 +37,7 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $exception)
     {
-        if ($this->shouldReport($exception)) {
+        if (app()->bound('sentry') && $this->shouldReport($exception)) {
             app('sentry')->captureException($exception);
         }
 


### PR DESCRIPTION
This could result in an error when for example accessing a bad route. It also seems like that the `.env.example` did not include the `SENTRY_DSN` variable