### PR TITLE
urlencode() added to escape url

### DIFF
--- a/app/Traits/Submit.php
+++ b/app/Traits/Submit.php
@@ -66,7 +66,7 @@ trait Submit
      */
     protected function linkSubmission(Request $request)
     {
-        $apiURL = 'https://midd.voten.co/link-submission?url='.$request->url;
+        $apiURL = 'https://midd.voten.co/link-submission?url='.urlencode($request->url);
 
         $info = json_decode(file_get_contents($apiURL));
 


### PR DESCRIPTION
There was a problem that the back part of URL, after first ampersand, was truncated when it was saved to DB.