### PR TITLE
Fix PHP version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.0.0",
         "laravel/framework": "5.4.*",
         "embed/embed": "3.*",
         "intervention/image": "^2.3",

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Voten is a Laravel application that runs on the following software:
 - Ubuntu 16.04.2 LTS
 - Nginx 1.10+
 - MySQL 5.7+ (to use mariaDB, you must modify `json` type migration columns to `blob`)
-- PHP 7.1+
+- PHP 7.0+
 - Redis 3.0+
 - Git 2.8.4+
 - [Pusher](https://pusher.com/)


### PR DESCRIPTION
For composer, this should be a given because of dependencies that require it and usage of ?? null coalescing operator. For the readme, I believe that this project will run just swell on PHP 7.0 even though you might have 7.1 installed for now.