### PR TITLE
Make use of existing functions for help center

### DIFF
--- a/app/Http/Controllers/HelpController.php
+++ b/app/Http/Controllers/HelpController.php
@@ -71,9 +71,9 @@ class HelpController extends Controller
      */
     public function showHelpCenter()
     {
-        $recent_questions = Help::orderBy('created_at', 'desc')->take(5)->get();
+        $recent_questions = $this->recentQuestions();
 
-        $common_questions = Help::orderBy('index', 'desc')->take(5)->get();
+        $common_questions = $this->commonQuestions();
 
         return view('help.index', compact('recent_questions', 'common_questions'));
     }


### PR DESCRIPTION
Calls functions in the HelpController that already exists instead of recreating the queries for showHelpCenter()