### PR TITLE
Add year to member joined date on UserHeader.vue

### DIFF
--- a/resources/assets/js/components/UserHeader.vue
+++ b/resources/assets/js/components/UserHeader.vue
@@ -248,8 +248,8 @@ export default {
 
         date() {
             return moment(this.userStore.created_at)
-                .utc(moment().format('MMM Do'))
-                .format('MMM Do');
+                .utc(moment().format('MMM Do YYYY'))
+                .format('MMM Do YYYY');
         },
 
         coverBackground() {


### PR DESCRIPTION
Currently the Joined on member profile only displays the month and day, this adds the year because voten is getting older now :) 