### PR TITLE
Add Special.lu agency note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,11 @@
 
 <hr>
 
-## Update:
+## Archived project by Special.lu
 
-I currently don't have the time that is required to maintain Voten. I am however open to contract work in case you need help with developing your fork of Voten, or any other development gig. You can reach me at algo@hey.com
+Voten is no longer actively maintained. It is preserved as one of [Special.lu](https://special.lu)'s older web design and development projects. You can explore a restored, sample-content-filled version at [voten.special.lu](https://voten.special.lu).
 
-My new open-source project is [Jesse](https://github.com/jesse-ai/jesse), an advanced cryptocurrency algo-trading framework written in Python. 
+[Special.lu](https://special.lu) is a Luxembourg creative and web design agency. If you need a new website, a redesign, or custom web development, [contact Special.lu](https://special.lu/contact) to discuss your project.
 
 <br>
 <hr>


### PR DESCRIPTION
## What changed

- identifies Voten as an archived Special.lu web design and development project
- links to the restored demo at `voten.special.lu`
- directs prospective web design and development clients to the Special.lu contact page

## Why

The project README should explain who created and preserves Voten, while giving visitors a current way to contact the agency for new web work.

## Validation

- reviewed the rendered Markdown structure and links
- confirmed `https://special.lu/contact` returns HTTP 200
- ran `git diff --check`
